### PR TITLE
Refactor `style = "bold"` to `bold = true`

### DIFF
--- a/lua/arshamiser/feliniser/init.lua
+++ b/lua/arshamiser/feliniser/init.lua
@@ -29,7 +29,7 @@ table.insert(components.active[1], {
     return {
       fg = "statusline_bg",
       bg = vi_mode_utils.get_mode_color(),
-      style = "bold",
+      bold = true
     }
   end,
   right_sep = "right_rounded",
@@ -41,7 +41,7 @@ table.insert(components.active[1], {
     return {
       fg = vi_mode_utils.get_mode_color(),
       bg = "statusline_bg",
-      style = "bold",
+      bold = true
     }
   end,
   right_sep = {
@@ -49,7 +49,7 @@ table.insert(components.active[1], {
     hl = {
       fg = "light_bg2",
       bg = "statusline_bg",
-      style = "bold",
+      bold = true
     },
   },
   icon = "  ",
@@ -67,7 +67,7 @@ table.insert(components.active[1], {
   hl = {
     fg = "green_pale",
     bg = "statusline_bg",
-    style = "bold",
+    bold = true
   },
   icon = "  ",
 })
@@ -160,7 +160,7 @@ table.insert(components.active[2], {
     hl = {
       fg = "statusline_bg",
       bg = "mid_bg",
-      style = "bold",
+      bold = true
     },
   },
 })
@@ -334,14 +334,14 @@ table.insert(components.active[3], {
   hl = {
     fg = "yellow",
     bg = "statusline_bg",
-    style = "bold",
+    bold = true
   },
   left_sep = {
     str = " ",
     hl = {
       bg = "statusline_bg",
       fg = "mid_bg",
-      style = "bold",
+      bold = true
     },
   },
 })
@@ -360,7 +360,7 @@ table.insert(components.active[3], {
     hl = {
       bg = "statusline_bg",
       fg = "mid_bg",
-      style = "bold",
+      bold = true
     },
   },
 })
@@ -393,7 +393,7 @@ table.insert(components.active[3], {
       val.fg = "grey_fg"
     end
     val.bg = "statusline_bg"
-    val.style = "bold"
+    val.bold = true
     return val
   end,
   left_sep = {
@@ -408,7 +408,7 @@ table.insert(components.active[3], {
     hl = {
       bg = "statusline_bg",
       fg = "mid_bg",
-      style = "bold",
+      bold = true
     },
   },
 })
@@ -431,7 +431,7 @@ table.insert(components.active[3], {
       val.fg = "grey_fg"
     end
     val.bg = "statusline_bg"
-    val.style = "bold"
+    val.bold = true
     return val
   end,
   priority = 7,
@@ -441,7 +441,7 @@ table.insert(components.active[3], {
     hl = {
       fg = "mid_bg",
       bg = "statusline_bg",
-      style = "bold",
+      bold = true
     },
   },
 })
@@ -467,7 +467,7 @@ table.insert(components.active[3], {
     hl = {
       fg = "mid_bg",
       bg = "statusline_bg",
-      style = "bold",
+      bold = true
     },
   },
 })
@@ -479,7 +479,7 @@ table.insert(components.active[3], { -- {{{
     return {
       fg = "light_bg",
       bg = vi_mode_utils.get_mode_color(),
-      style = "bold",
+      bold = true
     }
   end,
   left_sep = "left_rounded",
@@ -498,7 +498,7 @@ table.insert(components.active[3], {
     return {
       fg = "red_dark",
       bg = vi_mode_utils.get_mode_color(),
-      style = "bold",
+      bold = true
     }
   end,
 })
@@ -516,7 +516,7 @@ table.insert(components.active[3], {
     return {
       fg = "purple",
       bg = vi_mode_utils.get_mode_color(),
-      style = "bold",
+      bold = true
     }
   end,
 })
@@ -529,7 +529,7 @@ table.insert(components.active[3], {
     return {
       fg = "statusline_bg",
       bg = vi_mode_utils.get_mode_color(),
-      style = "bold",
+      bold = true
     }
   end,
   right_sep = {
@@ -538,7 +538,7 @@ table.insert(components.active[3], {
       return {
         fg = vi_mode_utils.get_mode_color(),
         bg = "statusline_bg",
-        style = "bold",
+        bold = true
       }
     end,
   },
@@ -550,7 +550,7 @@ table.insert(components.active[3], {
     return {
       fg = vi_mode_utils.get_mode_color(),
       bg = "statusline_bg",
-      style = "bold",
+      bold = true
     }
   end,
 })
@@ -660,7 +660,7 @@ table.insert(components.inactive[2], {
     hl = {
       bg = "mid_bg",
       fg = "short_bg",
-      style = "bold",
+      bold = true,
     },
   },
   right_sep = {
@@ -668,7 +668,7 @@ table.insert(components.inactive[2], {
     hl = {
       bg = "short_bg",
       fg = "mid_bg",
-      style = "bold",
+      bold = true
     },
   },
 })
@@ -679,7 +679,7 @@ table.insert(components.inactive[3], { -- {{{
   hl = {
     fg = "mid_bg",
     bg = "green_pale",
-    style = "bold",
+    bold = true
   },
   left_sep = {
     str = "slant_left",
@@ -714,7 +714,7 @@ table.insert(components.inactive[3], {
   hl = {
     fg = "light_bg",
     bg = "green_pale",
-    style = "bold",
+    bold = true
   },
 })
 

--- a/lua/arshamiser/heirliniser/init.lua
+++ b/lua/arshamiser/heirliniser/init.lua
@@ -30,7 +30,7 @@ local vim_mode = { --{{{
   hl = function(self)
     return {
       fg = util.mode_colour(self.mode_ch),
-      style = "bold",
+      bold = true
     }
   end,
   {
@@ -38,7 +38,7 @@ local vim_mode = { --{{{
       return {
         fg = util.colours.statusline_bg,
         bg = util.mode_colour(self.mode_ch),
-        style = "bold",
+        bold = true
       }
     end,
     provider = "  ",
@@ -55,7 +55,7 @@ local fold_method = { --{{{
     return vim.wo.foldenable
   end,
   {
-    hl = { fg = util.colours.green_pale, style = "bold" },
+    hl = { fg = util.colours.green_pale, bold = true },
     { provider = "  " },
     { provider = feliniser.fold_method },
   },
@@ -234,7 +234,7 @@ local locallist = { --{{{
 } --}}}
 
 local cursor_location = { --{{{
-  { provider = "%l/%L|%c ", hl = { style = "bold" } },
+  { provider = "%l/%L|%c ", hl = { bold = true } },
   {
     provider = " %P",
     hl = function(self)
@@ -322,7 +322,7 @@ local active_right_segment = { --{{{
     end,
     hl = {
       fg = util.colours.yellow,
-      style = "bold",
+      bold = true
     },
   }, --}}}
 
@@ -332,7 +332,7 @@ local active_right_segment = { --{{{
       hl = function(self)
         return {
           fg = self.icon_color,
-          style = "bold",
+          bold = true
         }
       end,
       space,


### PR DESCRIPTION
In the last version of Neovim the highlight settings migth made a break change.

![2022-06-27_16-49-52](https://user-images.githubusercontent.com/94197184/176033306-475a6a36-aad7-40d6-ab52-cd8e7ac01c5e.png)

In the [docs](https://neovim.io/doc/user/api.html) "style" is no longer a valid key for `{val}` in `nvim_set_hl({ns_id}, {name}, {*val}) ` function insted now is `bold : boolean`.