### PR TITLE
Fix the missing dependency lewis6991/gitsigns.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Use your favourite package manager to install this library.
 		"famiu/feline.nvim",
 		"rebelot/heirline.nvim",
 		"kyazdani42/nvim-web-devicons",
+		"lewis6991/gitsigns.nvim",
 	},
 	config = function()
 		-- ignore any parts you don't want to use
@@ -82,6 +83,7 @@ use({
     "famiu/feline.nvim",
     "rebelot/heirline.nvim",
     "kyazdani42/nvim-web-devicons",
+    "lewis6991/gitsigns.nvim",
   },
   config = function()
     -- ignore any parts you don't want to use
@@ -122,6 +124,7 @@ use({
     "rebelot/heirline.nvim",
     "kyazdani42/nvim-web-devicons",
     "nanotee/sqls.nvim",
+    "lewis6991/gitsigns.nvim",
   },
   config = function()
     vim.api.nvim_create_autocmd("UIEnter", {


### PR DESCRIPTION
`gitsigns.nvim` is used both directly (in `heirliniser`) and indirectly by `feline` (in `feliniser`). Without it properly set up, the respective functions return a `nil` value which results in the git information not showing up in status bar.